### PR TITLE
ci: Add docker image automated deploy and PR building

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,83 @@
+name: PR Workflow
+
+on:
+  pull_request_target:
+    types:
+      - labeled
+      - synchronize
+      - reopened
+      - opened
+    branches:
+      - 'main'
+
+jobs:
+  release-snapshot:
+    name: Release snapshot
+    runs-on: ubuntu-latest
+    needs: test
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'safe to test') && (vars.DOCKERHUB_IMAGE_NAME != '') }}
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ vars.DOCKERHUB_IMAGE_NAME }}
+          tags: |
+            type=ref,event=pr
+          flavor: |
+            latest=false
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v5
+        env:
+          APP_VERSION: ${{ format('pr{0}-{1}', github.event.number, github.event.pull_request.head.sha ) }}
+        with:
+          context: .
+          build-args: |
+            APP_BUILD_VERSION=${{env.APP_VERSION}}
+          push: ${{ !env.ACT}}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+
+  combine-and-comment:
+    name: Leave comment
+    runs-on: ubuntu-latest
+    needs: release-snapshot
+    if: contains(github.event.pull_request.labels.*.name, 'safe to test')
+    steps:
+      - name: Create comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          recreate: true
+          header: "pr-release"
+          message: |
+            #### :package: A new release has been made for this pull request.
+
+            To play around with this PR, pull an image:
+            * `need4swede/portall:pr-${{ github.event.number }}`
+
+            Images are available for x86_64 and ARM64.
+
+            > Latest commit: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/publishImage.yml
+++ b/.github/workflows/publishImage.yml
@@ -1,0 +1,89 @@
+name: Publish Docker image to Registries
+
+on:
+  workflow_dispatch:
+  push:
+    # add more branches that should be built->pushed automatically
+    # main will go to tag 'latest'
+    # all others will go to tag '{branch}'
+    branches:
+      - 'main'
+    tags:
+      - '*.*.*'
+    # don't trigger if just updating docs
+    paths-ignore:
+      - '**.md'
+      - '.github/**'
+
+jobs:
+  push_to_registry:
+    name: Build and push container images
+    if: ${{ github.event_name != 'pull_request' && (vars.DOCKERHUB_IMAGE_NAME != '' || vars.GHCR_IMAGE_NAME != '') }}
+    runs-on: ubuntu-latest
+    # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Set short git commit SHA
+        id: vars
+        # https://dev.to/hectorleiva/github-actions-and-creating-a-short-sha-hash-8b7
+        # short sha available under env.COMMIT_SHORT_SHA
+        run: |
+          calculatedSha=$(git rev-parse --short HEAD)
+          branchName=$(git rev-parse --abbrev-ref HEAD)
+          echo "COMMIT_SHORT_SHA=$calculatedSha" >> $GITHUB_ENV
+          echo "COMMIT_BRANCH=$branchName" >> $GITHUB_ENV
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ${{ vars.DOCKERHUB_IMAGE_NAME }}
+            ${{ vars.GHCR_IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable=${{ endsWith(github.ref, 'main') }}
+            type=ref,event=branch,enable=${{ !endsWith(github.ref, 'main') }}
+            type=semver,pattern={{version}}
+          flavor: |
+            latest=false
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        env:
+          # env provided to Dockerfile build arg APP_BUILD_VERSION
+          # when a tagged release is built uses tag name (1.0.1)
+          # when a branch push is built uses 'branch-commitSHA'
+          APP_VERSION: ${{ contains(github.ref, 'refs/tags/') && github.ref_name || format('{0}-{1}', env.COMMIT_BRANCH, env.COMMIT_SHORT_SHA ) }}
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          # https://github.com/docker/build-push-action/issues/1026#issue-2041857786
+          build-args: |
+            APP_BUILD_VERSION=${{env.APP_VERSION}}
+          push: ${{ !env.ACT}}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
To use the github actions workflow to deploy automatically to dockerhub and  [github packages](https://github.com/features/packages)

All below builds are cross-platform for x86/ARM.

# On Push

Triggers on these actions and publishes accordingly:

* On commit to `main` branch => published to dockerhub/ghcr `latest` tag
* On commit to any other branch (must explicitly be listed in workflow yaml) => publish to published to dockerhub/ghcr `yourBranchName` tag
* On release => published to dockerhub/ghcr using release `tag` Ie `1.0.1`

### To enable

* Go to [repository settings -> secrets and variables -> actions](https://github.com/davidguva/OpenVidReview/settings/secrets/actions)
  * Add repository secrets
    * `DOCKER_USERNAME` - your dockerhub username
    * `DOCKER_PASSWORD` - your dockerhub password
  * Add repository **variables**
    * `DOCKERHUB_IMAGE_NAME` - the full name of the dockerhub image IE `davidguva/openvidreview`
    * `GHCR_IMAGE_NAME` - the full name of the GHCR image IE `ghcr.io/davidguva/openvidreview`
    * If neither of the above variables are included then the job will not run
* Go to [repository settings -> Actions -> General](https://github.com/davidguva/OpenVidReview/settings/actions)
  *  Action permissions -> **Allow all actions...**
  * Workflow permissions -> **Read and write permissions**
  * Save

# On PR

The same settings apply as above except only for **dockerhub** for security considerations when using [`pull_request_trigger`](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) so that the action does not need repo write permissions. 

When a PR targeting `main` opened it will be built and published to dockerhub `pr[issueNumber]` EX `pr152` and a comment with a link to the built image will be made in the PR. However this **only happens** if the PR has the label `safe to test`  so you have a chance to review PR for malicious changes to github actions workflow or other things.

___

The docker build action is also provided a build arg `APP_BUILD_VERSION` that could be used by your application to display the built version based on tag or branch or pr...modify you Dockerfile with 

```dockerfile
ARG APP_BUILD_VERSION
ENV APP_VERSION=$APP_BUILD_VERSION
```

And then reference `APP_VERSION` env within your app to get the version like:

* On tag release => `1.0.1`
* On branch build `featureBranch-088d063`
* On PR `pr152-088d063`