### PR TITLE
V1.0.6 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🚢 Portall - Port Management System
 
-![Version](https://img.shields.io/badge/version-1.0.5-blue.svg)
+![Version](https://img.shields.io/badge/version-1.0.6-blue.svg)
 ![License](https://img.shields.io/badge/license-MIT-green.svg)
 ![Docker](https://img.shields.io/badge/docker-ready-brightgreen.svg)
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,21 @@
 # <a href="https://github.com/need4swede/portall/releases/tag/v1.0.6" target="_blank">v1.0.6</a>
+## Added:
+### Port Protocols
+Portall now supports setting different protocols for ports (TCP/UDP).
+
+You can choose protocols when generating new ports (default is TCP), when creating new ones, and when editing existing ones. Two identical port numbers can both be registered to a single IP if they have different protocols. If you try to add an entry that already has a matching port and protocol, it will trigger the Port Conflict Resolver.
+
+If you add ports from an import, such as a Caddyfile or Docker-Compose, that doesn't explicitly state what protocols are being used, it will default to TCP.
+### Loading Animation
+Certain actions, like port conflict resolutions and moving IP panels, now trigger a loading animation that prevents further action until the changes have registered.
+## Changed:
+### Database
+**Breaking Changes!** Database changes required for new port protocol feature.
+### Docker-Compose Imports
+Now supports `/tcp` and `/udp` properties to differentiate between the two protocols.
 ## Fixed:
-### <a href="https://github.com/need4swede/Portall/issues/10" target="_blank">Theme Settings Reset</a>
-Fixed an issue where theme settings would reset if you made changes in the settings.
+### <a href="https://github.com/need4swede/Portall/issues/10" target="_blank">Settings Reset</a>
+Fixed an issue where certain settings would reset if you made changes in the settings.
 
 # <a href="https://github.com/need4swede/portall/releases/tag/v1.0.5" target="_blank">v1.0.5</a>
 ## Added:

--- a/changelog.md
+++ b/changelog.md
@@ -1,13 +1,18 @@
+# <a href="https://github.com/need4swede/portall/releases/tag/v1.0.6" target="_blank">v1.0.6</a>
+## Fixed:
+### <a href="https://github.com/need4swede/Portall/issues/10" target="_blank">Theme Settings Reset</a>
+Fixed an issue where theme settings would reset if you made changes in the settings.
+
 # <a href="https://github.com/need4swede/portall/releases/tag/v1.0.5" target="_blank">v1.0.5</a>
 ## Added:
 ### <a href="https://github.com/need4swede/Portall/issues/7" target="_blank">Data Export</a>
 You can now export your entries to a JSON file.
 ## Changed:
 ### JSON Import
-Updated the format of JSON imports to match the new export
+Updated the format of JSON imports to match the new export,
 ## Fixed:
 ### <a href="https://github.com/need4swede/Portall/issues/14" target="_blank">Newly Added Port Order</a>
-Fixed an issue where newly added ports would get placed near the beggining of the stack. Now they get appended to the end.
+Fixed an issue where newly added ports would get placed near the beggining of the stack. Now they get appended to the end,
 
 # <a href="https://github.com/need4swede/portall/releases/tag/v1.0.4" target="_blank">v1.0.4</a>
 ## Added:

--- a/static/css/global/styles.css
+++ b/static/css/global/styles.css
@@ -108,6 +108,36 @@ h1 {
     min-height: calc(100% - 1rem);
 }
 
+/* Modern select styling */
+.modern-select {
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    background-color: var(--color-gray-lighter);
+    border: 1px solid var(--color-gray-light);
+    border-radius: var(--border-radius);
+    padding: 0.5rem 2rem 0.5rem 1rem;
+    font-size: 1rem;
+    line-height: 1.5;
+    color: var(--color-gray-dark);
+    cursor: pointer;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23333' d='M10.293 3.293L6 7.586 1.707 3.293A1 1 0 00.293 4.707l5 5a1 1 0 001.414 0l5-5a1 1 0 10-1.414-1.414z'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 1rem center;
+    background-size: 0.75rem;
+    transition: border-color var(--transition-duration) ease, box-shadow var(--transition-duration) ease;
+}
+
+.modern-select:hover {
+    border-color: var(--color-blue-light);
+}
+
+.modern-select:focus {
+    outline: none;
+    border-color: var(--color-blue);
+    box-shadow: 0 0 0 2px var(--color-blue-shadow);
+}
+
 @media (min-width: 576px) {
     .modal-dialog {
         min-height: calc(100% - 3.5rem);

--- a/static/css/global/styles.css
+++ b/static/css/global/styles.css
@@ -209,6 +209,13 @@ h1 {
     text-overflow: ellipsis;
 }
 
+.port-protocol {
+    color: var(--color-teal);
+    text-align: center;
+    font-weight: bold;
+    margin: 0;
+}
+
 .port-tooltip {
     visibility: hidden;
     width: 200px;

--- a/static/js/api/ajax/helpers.js
+++ b/static/js/api/ajax/helpers.js
@@ -27,15 +27,21 @@ export function movePort(portNumber, sourceIp, targetIp, protocol, successCallba
         },
         success: function (response) {
             if (response.success) {
-                successCallback();
+                if (typeof successCallback === 'function') {
+                    successCallback();
+                }
             } else {
                 showNotification('Error moving port: ' + response.message, 'error');
-                errorCallback();
+                if (typeof errorCallback === 'function') {
+                    errorCallback();
+                }
             }
         },
         error: function (xhr, status, error) {
             showNotification('Error moving port: ' + error, 'error');
-            errorCallback();
+            if (typeof errorCallback === 'function') {
+                errorCallback();
+            }
         }
     });
 }

--- a/static/js/api/ajax/helpers.js
+++ b/static/js/api/ajax/helpers.js
@@ -15,30 +15,27 @@ import { cancelDrop } from '../../utils/dragDropUtils.js';
  * @param {function} updatePortOrder - Function to update the port order
  * @param {function} cancelDropFn - Function to cancel the drop operation
  */
-export function movePort(portNumber, sourceIp, targetIp, targetElement, draggingElement, updatePortOrder, cancelDropFn) {
+export function movePort(portNumber, sourceIp, targetIp, protocol, successCallback, errorCallback) {
     $.ajax({
         url: '/move_port',
         method: 'POST',
         data: {
             port_number: portNumber,
             source_ip: sourceIp,
-            target_ip: targetIp
+            target_ip: targetIp,
+            protocol: protocol
         },
         success: function (response) {
             if (response.success) {
-                // Update port order for both source and target IPs
-                updatePortOrder(sourceIp);
-                if (sourceIp !== targetIp) {
-                    updatePortOrder(targetIp);
-                }
+                successCallback();
             } else {
                 showNotification('Error moving port: ' + response.message, 'error');
-                cancelDropFn();
+                errorCallback();
             }
         },
         error: function (xhr, status, error) {
             showNotification('Error moving port: ' + error, 'error');
-            cancelDropFn();
+            errorCallback();
         }
     });
 }

--- a/static/js/api/ajax/helpers.js
+++ b/static/js/api/ajax/helpers.js
@@ -10,12 +10,12 @@ import { cancelDrop } from '../../utils/dragDropUtils.js';
  * @param {number} portNumber - The port number being moved
  * @param {string} sourceIp - The source IP address
  * @param {string} targetIp - The target IP address
- * @param {HTMLElement} targetElement - The target element for insertion
- * @param {HTMLElement} draggingElement - The element being dragged
- * @param {function} updatePortOrder - Function to update the port order
- * @param {function} cancelDropFn - Function to cancel the drop operation
+ * @param {string} protocol - The protocol of the port (TCP or UDP)
+ * @param {function} successCallback - Function to call on successful move
+ * @param {function} errorCallback - Function to call on move error
  */
 export function movePort(portNumber, sourceIp, targetIp, protocol, successCallback, errorCallback) {
+    console.log(`Attempting to move port: ${portNumber} (${protocol}) from ${sourceIp} to ${targetIp}`);
     $.ajax({
         url: '/move_port',
         method: 'POST',
@@ -23,12 +23,13 @@ export function movePort(portNumber, sourceIp, targetIp, protocol, successCallba
             port_number: portNumber,
             source_ip: sourceIp,
             target_ip: targetIp,
-            protocol: protocol
+            protocol: protocol.toUpperCase()  // Ensure protocol is uppercase
         },
         success: function (response) {
+            console.log('Server response:', response);
             if (response.success) {
                 if (typeof successCallback === 'function') {
-                    successCallback();
+                    successCallback(response.port);  // Pass the updated port data
                 }
             } else {
                 showNotification('Error moving port: ' + response.message, 'error');
@@ -38,6 +39,7 @@ export function movePort(portNumber, sourceIp, targetIp, protocol, successCallba
             }
         },
         error: function (xhr, status, error) {
+            console.log('Error response:', xhr.responseText);
             showNotification('Error moving port: ' + error, 'error');
             if (typeof errorCallback === 'function') {
                 errorCallback();

--- a/static/js/core/dragAndDrop.js
+++ b/static/js/core/dragAndDrop.js
@@ -277,23 +277,25 @@ function finalizeDrop(targetElement) {
     if (sourceIp !== targetIp) {
         console.log('Moving port to a different IP group');
         const portNumber = $(draggingElement).find('.port').data('port');
+        const protocol = $(draggingElement).find('.port').data('protocol');
 
-        // Check if the port number already exists in the target IP group
-        if (checkPortExists(targetIp, portNumber)) {
+        // Check if the port number and protocol combination already exists in the target IP group
+        if (checkPortExists(targetIp, portNumber, protocol)) {
             conflictingPortData = {
                 sourceIp: sourceIp,
                 targetIp: targetIp,
                 portNumber: portNumber,
+                protocol: protocol,
                 targetElement: targetElement,
                 draggingElement: draggingElement
             };
-            $('#conflictingPortNumber').text(portNumber);
+            $('#conflictingPortNumber').text(`${portNumber} (${protocol})`);
             $('#portConflictModal').modal('show');
             return;
         }
 
         // If no conflict, proceed with the move
-        proceedWithMove(portNumber, sourceIp, targetIp, targetElement, draggingElement);
+        proceedWithMove(portNumber, protocol, sourceIp, targetIp, targetElement, draggingElement);
     } else {
         console.log('Reordering within the same IP group');
         targetElement.parentNode.insertBefore(draggingElement, targetElement);

--- a/static/js/core/dragAndDrop.js
+++ b/static/js/core/dragAndDrop.js
@@ -307,7 +307,7 @@ function finalizeDrop(targetElement) {
     sourceIp = null;
 }
 
-function proceedWithMove(portNumber, sourceIp, targetIp, targetElement, draggingElement, isConflictResolution = false) {
+function proceedWithMove(portNumber, protocol, sourceIp, targetIp, targetElement, draggingElement, isConflictResolution = false) {
     // Insert the dragged element before the target element
     $(targetElement).before(draggingElement);
 
@@ -317,7 +317,7 @@ function proceedWithMove(portNumber, sourceIp, targetIp, targetElement, dragging
     $(draggingElement).find('.port').attr('data-nickname', targetNickname);
 
     // Move port on the server and update orders
-    movePort(portNumber, sourceIp, targetIp, targetElement, draggingElement, function () {
+    movePort(portNumber, sourceIp, targetIp, protocol, function () {
         updatePortOrder(sourceIp);
         updatePortOrder(targetIp);
         if (isConflictResolution) {

--- a/static/js/core/dragAndDrop.js
+++ b/static/js/core/dragAndDrop.js
@@ -181,7 +181,7 @@ function initiateDrag(e, element) {
         'zIndex': 1000,
         'pointer-events': 'none',
         'width': $(draggingElement).width() + 'px',
-        'height': $(draggingElement).height() + 'px'
+        'height': $(draggingElement).height() + 10 + 'px'
     }).appendTo('body');
 
     // Handle mouse movement during drag

--- a/static/js/core/dragAndDrop.js
+++ b/static/js/core/dragAndDrop.js
@@ -279,6 +279,9 @@ function finalizeDrop(targetElement) {
         const portNumber = $(draggingElement).find('.port').data('port');
         const protocol = $(draggingElement).find('.port').data('protocol');
 
+        console.log('Port number:', portNumber);
+        console.log('Protocol:', protocol);
+
         // Check if the port number and protocol combination already exists in the target IP group
         if (checkPortExists(targetIp, portNumber, protocol)) {
             conflictingPortData = {

--- a/static/js/core/dragAndDrop.js
+++ b/static/js/core/dragAndDrop.js
@@ -311,22 +311,37 @@ function finalizeDrop(targetElement) {
 }
 
 function proceedWithMove(portNumber, protocol, sourceIp, targetIp, targetElement, draggingElement, isConflictResolution = false) {
+    console.log(`Proceeding with move: ${portNumber} (${protocol}) from ${sourceIp} to ${targetIp}`);
+    console.log('Dragging element:', draggingElement);
+    console.log('Target element:', targetElement);
+
     // Insert the dragged element before the target element
     $(targetElement).before(draggingElement);
 
-    // Update the port's IP and other attributes
-    $(draggingElement).find('.port').attr('data-ip', targetIp);
-    const targetNickname = $(targetElement).closest('.network-switch').find('.edit-ip').data('nickname');
-    $(draggingElement).find('.port').attr('data-nickname', targetNickname);
-
     // Move port on the server and update orders
-    movePort(portNumber, sourceIp, targetIp, protocol, function () {
+    movePort(portNumber, sourceIp, targetIp, protocol, function (updatedPort) {
+        console.log(`Move successful: ${portNumber} (${protocol}) from ${sourceIp} to ${targetIp}`);
+
+        // Update the dragged element with new data
+        const $port = $(draggingElement).find('.port');
+        $port.attr('data-ip', updatedPort.ip_address);
+        $port.attr('data-port', updatedPort.port_number);
+        $port.attr('data-protocol', updatedPort.protocol);
+        $port.attr('data-description', updatedPort.description);
+        $port.attr('data-order', updatedPort.order);
+        $port.attr('data-id', updatedPort.id);
+
+        // Update the port's IP and other attributes
+        const targetNickname = $(targetElement).closest('.network-switch').find('.edit-ip').data('nickname');
+        $port.attr('data-nickname', targetNickname);
+
         updatePortOrder(sourceIp);
         updatePortOrder(targetIp);
         if (isConflictResolution) {
             refreshPageAfterDelay();
         }
     }, function () {
+        console.log(`Move failed: ${portNumber} (${protocol}) from ${sourceIp} to ${targetIp}`);
         cancelDrop();
     });
 }

--- a/static/js/core/dragAndDrop.js
+++ b/static/js/core/dragAndDrop.js
@@ -46,10 +46,7 @@ function handleMouseDown(e) {
     if (e.which !== 1) return; // Only respond to left mouse button
 
     const panel = $(this).closest('.switch-panel');
-    if (panel.find('.port-slot:not(.add-port-slot)').length === 1) {
-        showNotification("Can't move the last port in a panel", 'error');
-        return;
-    }
+    const isLastPort = panel.find('.port-slot:not(.add-port-slot)').length === 1;
 
     dragStartX = e.clientX;
     dragStartY = e.clientY;
@@ -60,6 +57,11 @@ function handleMouseDown(e) {
         if (!isDragging &&
             (Math.abs(e.clientX - dragStartX) > dragThreshold ||
                 Math.abs(e.clientY - dragStartY) > dragThreshold)) {
+            if (isLastPort) {
+                showNotification("Can't move the last port in a panel", 'error');
+                $(document).off('mousemove.dragdetect mouseup.dragdetect');
+                return;
+            }
             isDragging = true;
             initiateDrag(e, element);
         }

--- a/static/js/core/dragAndDrop.js
+++ b/static/js/core/dragAndDrop.js
@@ -119,7 +119,8 @@ function handleNetworkSwitchDragOver(e) {
 
 /**
  * Handle drag end event for IP panels.
- * Finalizes the drag operation and updates the order of panels.
+ * Finalizes the drag operation, updates the order of panels,
+ * shows a loading animation, and refreshes the page.
  *
  * @param {Event} e - The dragend event object
  */
@@ -131,7 +132,16 @@ function handleNetworkSwitchDragEnd(e) {
         ipPanelPlaceholder.parentNode.removeChild(ipPanelPlaceholder);
     }
 
-    setTimeout(updateIPPanelOrder, 0);
+    // Update IP panel order
+    updateIPPanelOrder(() => {
+        // Show loading animation
+        showLoadingAnimation();
+
+        // Refresh the page after a short delay
+        setTimeout(() => {
+            location.reload();
+        }, 1500); // 1.5 seconds delay
+    });
 }
 
 /**

--- a/static/js/core/dragAndDrop.js
+++ b/static/js/core/dragAndDrop.js
@@ -323,7 +323,9 @@ function proceedWithMove(portNumber, protocol, sourceIp, targetIp, targetElement
         if (isConflictResolution) {
             refreshPageAfterDelay();
         }
-    }, cancelDrop);
+    }, function () {
+        cancelDrop();
+    });
 }
 
 /**
@@ -366,11 +368,11 @@ $('#confirmPortChange').click(function () {
 
     if (isChangingMigrating) {
         changePortNumber(conflictingPortData.sourceIp, conflictingPortData.portNumber, newPortNumber, function () {
-            proceedWithMove(newPortNumber, conflictingPortData.sourceIp, conflictingPortData.targetIp, conflictingPortData.targetElement, conflictingPortData.draggingElement, true);
+            proceedWithMove(newPortNumber, conflictingPortData.protocol, conflictingPortData.sourceIp, conflictingPortData.targetIp, conflictingPortData.targetElement, conflictingPortData.draggingElement, true);
         });
     } else {
         changePortNumber(conflictingPortData.targetIp, conflictingPortData.portNumber, newPortNumber, function () {
-            proceedWithMove(conflictingPortData.portNumber, conflictingPortData.sourceIp, conflictingPortData.targetIp, conflictingPortData.targetElement, conflictingPortData.draggingElement, true);
+            proceedWithMove(conflictingPortData.portNumber, conflictingPortData.protocol, conflictingPortData.sourceIp, conflictingPortData.targetIp, conflictingPortData.targetElement, conflictingPortData.draggingElement, true);
         });
     }
 

--- a/static/js/core/ipManagement.js
+++ b/static/js/core/ipManagement.js
@@ -92,7 +92,12 @@ function handleDeleteIpModalHidden() {
     deleteIpAddress = null;
 }
 
-export function updateIPPanelOrder() {
+/**
+ * Update the order of IP panels and execute a callback function.
+ *
+ * @param {Function} callback - Function to be called after updating the order
+ */
+export function updateIPPanelOrder(callback) {
     const ipOrder = [];
     $('.network-switch').each(function () {
         ipOrder.push($(this).data('ip'));
@@ -106,7 +111,12 @@ export function updateIPPanelOrder() {
         data: JSON.stringify({ ip_order: ipOrder }),
         contentType: 'application/json',
         success: function (response) {
-            if (!response.success) {
+            if (response.success) {
+                console.log('IP panel order updated successfully');
+                if (typeof callback === 'function') {
+                    callback();
+                }
+            } else {
                 showNotification('Error updating IP panel order: ' + response.message, 'error');
                 location.reload();
             }

--- a/static/js/core/new.js
+++ b/static/js/core/new.js
@@ -6,6 +6,8 @@
  * generating ports based on user input.
  */
 
+import { showNotification } from '../ui/helpers.js';
+
 $(document).ready(function () {
     console.log('Document ready');
     const ipSelect = $('#ip-address');

--- a/static/js/core/new.js
+++ b/static/js/core/new.js
@@ -55,6 +55,7 @@ $(document).ready(function () {
         const ipAddress = ipSelect.val();
         const selectedOption = ipSelect.find('option:selected');
         const nickname = selectedOption.text().match(/\((.*?)\)/)?.[1] || '';
+        const portProtocol = $('#protocol').val();
         if (!ipAddress) {
             alert('Please select or enter an IP address');
             return;
@@ -67,7 +68,8 @@ $(document).ready(function () {
             data: {
                 ip_address: ipAddress,
                 nickname: nickname,
-                description: $('#description').val()
+                description: $('#description').val(),
+                protocol: portProtocol
             },
             success: function (response) {
                 console.log('Port generated successfully:', response);

--- a/static/js/core/portManagement.js
+++ b/static/js/core/portManagement.js
@@ -48,6 +48,7 @@ export function init() {
     $('#deletePortModal').on('hidden.bs.modal', handleDeletePortModalHidden);
     $('#new-port-number').on('input', handleNewPortNumberInput);
     $('#add-new-port-number').on('input', handleAddNewPortNumberInput);
+    $('#add-port-protocol').on('change', handleAddNewPortNumberInput);
     $('#port-protocol').on('change', handleNewPortNumberInput);
     $('#new-port-number').on('input', handleNewPortNumberInput);
     $('#port-protocol').on('change', handleProtocolChange);
@@ -251,6 +252,7 @@ function handleAddPortClick() {
     $('#display-add-port-ip').text(ip);
     $('#add-new-port-number').val('');
     $('#add-port-description').val('');
+    $('#add-port-protocol').val('TCP');  // Reset to TCP by default
     $('#port-exists-disclaimer').hide();
     $('#save-new-port').prop('disabled', false);
     addPortModal.show();
@@ -332,10 +334,12 @@ function handleSaveNewPortClick() {
     const ip = $('#add-port-ip').val();
     const portNumber = $('#add-new-port-number').val().trim();
     const description = $('#add-port-description').val().trim();
+    const protocol = $('#add-port-protocol').val(); // Add this line to get the protocol
 
     console.log("IP:", ip);
     console.log("Port Number:", portNumber);
     console.log("Description:", description);
+    console.log("Protocol:", protocol); // Log the protocol
 
     if (portNumber === '') {
         console.log("Port number is empty");
@@ -349,7 +353,7 @@ function handleSaveNewPortClick() {
         return;
     }
 
-    if (checkPortExists(ip, portNumber)) {
+    if (checkPortExists(ip, portNumber, protocol)) { // Include protocol in the check
         console.log("Port already exists");
         showNotification('Port already exists', 'error');
         return;
@@ -371,14 +375,15 @@ function handleSaveNewPortClick() {
 
                 // Create the new port element
                 const newPortElement = `
-                    <div class="port-slot" draggable="true" data-port="${portNumber}" data-order="${response.order}">
-                        <div class="port active" data-ip="${ip}" data-port="${portNumber}" data-description="${description}"
-                            data-order="${response.order}" data-id="${response.id}">
-                            <span class="port-number">${portNumber}</span>
-                            <span class="port-description">${description}</span>
-                            <div class="port-tooltip">${description}</div>
-                        </div>
+                <div class="port-slot" draggable="true" data-port="${portNumber}" data-order="${response.order}">
+                    <div class="port active" data-ip="${ip}" data-port="${portNumber}" data-description="${description}"
+                        data-order="${response.order}" data-id="${response.id}" data-protocol="${protocol}">
+                        <span class="port-number">${portNumber}</span>
+                        <span class="port-description">${description}</span>
+                        <div class="port-tooltip">${description}</div>
                     </div>
+                    <p class="port-protocol">${protocol}</p>
+                </div>
                 `;
 
                 // Insert the new port element before the add-port-slot
@@ -464,6 +469,7 @@ function handleAddNewPortNumberInput() {
     console.log("Port number input changed. New value:", this.value);
     const ip = $('#add-port-ip').val();
     const portNumber = $(this).val().trim();
+    const protocol = $('#add-port-protocol').val();  // Get the selected protocol
 
     if (portNumber === '') {
         $('#port-exists-disclaimer').hide();
@@ -471,11 +477,11 @@ function handleAddNewPortNumberInput() {
         return;
     }
 
-    const portExists = checkPortExists(ip, portNumber);
+    const portExists = checkPortExists(ip, portNumber, protocol);  // Pass protocol to checkPortExists
 
     if (portExists) {
-        const description = $(`.port[data-ip="${ip}"][data-port="${portNumber}"]`).data('description');
-        $('#port-exists-disclaimer').text(`Port ${portNumber} already assigned to ${description}`).show();
+        const description = $(`.port[data-ip="${ip}"][data-port="${portNumber}"][data-protocol="${protocol}"]`).data('description');
+        $('#port-exists-disclaimer').text(`Port ${portNumber} (${protocol}) already assigned to ${description}`).show();
         $('#save-new-port').prop('disabled', true);
     } else {
         $('#port-exists-disclaimer').hide();

--- a/static/js/core/portManagement.js
+++ b/static/js/core/portManagement.js
@@ -56,6 +56,7 @@ export function handlePortClick(element) {
     const portNumber = port.data('port');
     const description = port.data('description');
     const portId = port.data('id');
+    const protocol = port.data('protocol'); // Add this line
 
     console.log("Port clicked - ID:", portId);
 
@@ -69,6 +70,7 @@ export function handlePortClick(element) {
     $('#old-port-number').val(portNumber);
     $('#new-port-number').val(portNumber);
     $('#port-description').val(description);
+    $('#port-protocol').val(protocol);
     $('#port-id').val(portId);
 
     // Disable delete button if it's the last port in the panel
@@ -96,9 +98,9 @@ export function handlePortClick(element) {
  * @param {string|null} currentPortId - The current port ID to exclude from the check
  * @returns {boolean} - True if the port exists, false otherwise
  */
-export function checkPortExists(ip, portNumber, currentPortId) {
-    console.log("Checking if port exists:", ip, portNumber, currentPortId);
-    const portElement = $(`.port[data-ip="${ip}"][data-port="${portNumber}"]`);
+export function checkPortExists(ip, portNumber, protocol, currentPortId) {
+    console.log("Checking if port exists:", ip, portNumber, protocol, currentPortId);
+    const portElement = $(`.port[data-ip="${ip}"][data-port="${portNumber}"][data-protocol="${protocol}"]`);
     console.log("Port element found:", portElement.length > 0);
     console.log("Port element data-id:", portElement.data('id'));
     if (currentPortId) {
@@ -214,10 +216,12 @@ function handleSavePortClick() {
     const portNumber = $('#new-port-number').val().trim();
     const description = $('#port-description').val().trim();
     const currentPortId = $('#port-id').val();
+    const protocol = $('#port-protocol').val(); // Add this line
 
     console.log("IP:", ip);
     console.log("Port Number:", portNumber);
     console.log("Description:", description);
+    console.log("Protocol:", protocol); // Add this line
 
     if (portNumber === '') {
         console.log("Port number is empty");
@@ -231,7 +235,7 @@ function handleSavePortClick() {
         return;
     }
 
-    if (checkPortExists(ip, portNumber, currentPortId)) {
+    if (checkPortExists(ip, portNumber, protocol, currentPortId)) {
         console.log("Port already exists");
         showNotification('Port already exists', 'error');
         return;
@@ -240,6 +244,7 @@ function handleSavePortClick() {
     console.log("All checks passed, proceeding with AJAX call");
     const formData = $('#edit-port-form').serialize();
     console.log("Form data:", formData);
+
 
     $.ajax({
         url: '/edit_port',

--- a/static/js/core/portManagement.js
+++ b/static/js/core/portManagement.js
@@ -111,7 +111,7 @@ export function handlePortClick(element) {
  */
 export function checkPortExists(ip, portNumber, protocol, currentPortId) {
     console.log("Checking if port exists:", ip, portNumber, protocol, currentPortId);
-    const portElement = $(`.port[data-ip="${ip}"][data-port="${portNumber}"][data-protocol="${protocol}"]`);
+    const portElement = $(`.port[data-ip="${ip}"][data-port="${portNumber}"][data-protocol="${protocol.toUpperCase()}"]`);
     console.log("Port element found:", portElement.length > 0);
     console.log("Port element data-id:", portElement.data('id'));
     if (currentPortId) {
@@ -154,6 +154,18 @@ export function updatePortOrder(ip) {
             console.error('Error updating port order:', error);
             showNotification('Error updating port order: ' + error, 'error');
         }
+    });
+}
+
+/**
+ * Verify port data in the frontend
+ * This function logs all port data currently displayed in the frontend
+ */
+export function verifyPortData() {
+    console.log("Verifying frontend port data:");
+    $('.port').each(function () {
+        const $port = $(this);
+        console.log(`Port: ${$port.data('port')}, IP: ${$port.data('ip')}, Protocol: ${$port.data('protocol')}, Description: ${$port.data('description')}`);
     });
 }
 

--- a/static/js/ui/animations.js
+++ b/static/js/ui/animations.js
@@ -1,4 +1,4 @@
-// static/js/animations.js
+// static/js/ui/animations.js
 
 /**
  * Application: Animation Logic

--- a/templates/base.html
+++ b/templates/base.html
@@ -47,7 +47,7 @@
     </div>
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="{{ url_for('static', filename='js/ui/animations.js') }}"></script>
+    <script type="module" src="{{ url_for('static', filename='js/ui/animations.js') }}"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.62.0/codemirror.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.62.0/mode/css/css.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.62.0/addon/edit/closebrackets.min.js"></script>

--- a/templates/new.html
+++ b/templates/new.html
@@ -20,6 +20,13 @@
         <label for="description" class="form-label">Description</label>
         <input type="text" class="form-control" id="description" name="description" required>
     </div>
+    <div class="mb-3">
+        <label for="protocol" class="form-label">Protocol</label>
+        <select class="form-select" id="protocol" name="protocol" required>
+            <option value="tcp">TCP</option>
+            <option value="udp">UDP</option>
+        </select>
+    </div>
     <button type="submit" class="btn btn-primary">Generate</button>
 </form>
 <div id="result" class="mt-3"></div>

--- a/templates/new.html
+++ b/templates/new.html
@@ -59,5 +59,5 @@
 {% endblock %}
 
 {% block scripts %}
-<script src="{{ url_for('static', filename='js/core/new.js') }}"></script>
+<script type="module" src="{{ url_for('static', filename='js/core/new.js') }}"></script>
 {% endblock %}

--- a/templates/new.html
+++ b/templates/new.html
@@ -23,8 +23,8 @@
     <div class="mb-3">
         <label for="protocol" class="form-label">Protocol</label>
         <select class="form-select" id="protocol" name="protocol" required>
-            <option value="tcp">TCP</option>
-            <option value="udp">UDP</option>
+            <option value="TCP">TCP</option>
+            <option value="UDP">UDP</option>
         </select>
     </div>
     <button type="submit" class="btn btn-primary">Generate</button>

--- a/templates/ports.html
+++ b/templates/ports.html
@@ -122,6 +122,12 @@
                         <label for="add-port-description" class="form-label">Description</label>
                         <input type="text" class="form-control" id="add-port-description" name="description" required>
                     </div>
+                    <div class="mb-3">
+                        <select id="add-port-protocol" name="protocol" class="modern-select">
+                            <option value="TCP">TCP</option>
+                            <option value="UDP">UDP</option>
+                        </select>
+                    </div>
                     <div id="port-exists-disclaimer" class="text-danger mt-2" style="display: none;"></div>
                 </form>
             </div>

--- a/templates/ports.html
+++ b/templates/ports.html
@@ -15,7 +15,7 @@
         <div class="port-slot" draggable="true" data-port="{{ port.port_number }}" data-order="{{ port.order }}">
             <div class="port {% if port.port_number in data.ports|map(attribute='port_number') %}active{% endif %}"
                 data-ip="{{ ip }}" data-port="{{ port.port_number }}" data-description="{{ port.description }}"
-                data-order="{{ port.order }}" data-id="{{ port.id }}">
+                data-order="{{ port.order }}" data-id="{{ port.id }}" data-protocol="{{ port.port_protocol }}">
                 <span class="port-number">{{ port.port_number }}</span>
                 <span class="port-description">{{ port.description }}</span>
                 <div class="port-tooltip">{{ port.description }}</div>
@@ -84,6 +84,12 @@
                     <div class="mb-3">
                         <label for="port-description" class="form-label">Description</label>
                         <input type="text" class="form-control" id="port-description" name="description" required>
+                    </div>
+                    <div class="mb-3">
+                        <select id="port-protocol" name="protocol">
+                            <option value="TCP">TCP</option>
+                            <option value="UDP">UDP</option>
+                        </select>
                     </div>
                 </form>
             </div>

--- a/templates/ports.html
+++ b/templates/ports.html
@@ -20,6 +20,7 @@
                 <span class="port-description">{{ port.description }}</span>
                 <div class="port-tooltip">{{ port.description }}</div>
             </div>
+            <p class="port-protocol">{{ port.port_protocol }}</p>
         </div>
         {% endfor %}
         <div class="port-slot add-port-slot">

--- a/templates/ports.html
+++ b/templates/ports.html
@@ -86,7 +86,7 @@
                         <input type="text" class="form-control" id="port-description" name="description" required>
                     </div>
                     <div class="mb-3">
-                        <select id="port-protocol" name="protocol">
+                        <select id="port-protocol" name="protocol" class="modern-select">
                             <option value="TCP">TCP</option>
                             <option value="UDP">UDP</option>
                         </select>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -185,7 +185,7 @@
                 <h3 class="card-title">Version Info</h3>
                 <ul class="list-unstyled">
                     <li><span class="info-label">Version:</span> {{ version }}</li>
-                    <li><span class="info-label">Released:</span> July 10, 2024</li>
+                    <li><span class="info-label">Released:</span> July 11, 2024</li>
                     <li><span class="info-label">Github:</span> <a href="https://github.com/need4swede/Portall"
                             target="_blank">Portall Repository</a></li>
                 </ul>

--- a/utils/database/port.py
+++ b/utils/database/port.py
@@ -11,4 +11,4 @@ class Port(db.Model):
     description = db.Column(db.String(100), nullable=False)
     order = db.Column(db.Integer, default=0)
 
-    __table_args__ = (db.UniqueConstraint('ip_address', 'port_number', name='_ip_port_uc'),)
+    __table_args__ = (db.UniqueConstraint('ip_address', 'port_number', 'port_protocol', name='_ip_port_protocol_uc'),)

--- a/utils/database/port.py
+++ b/utils/database/port.py
@@ -5,7 +5,7 @@ from .db import db
 class Port(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     ip_address = db.Column(db.String(15), nullable=False)
-    nickname = db.Column(db.String(50), nullable=False)
+    nickname = db.Column(db.String(50))
     port_number = db.Column(db.Integer, nullable=False)
     port_protocol = db.Column(db.String(3), nullable=False)
     description = db.Column(db.String(100), nullable=False)

--- a/utils/database/port.py
+++ b/utils/database/port.py
@@ -5,8 +5,9 @@ from .db import db
 class Port(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     ip_address = db.Column(db.String(15), nullable=False)
-    nickname = db.Column(db.String(50))
+    nickname = db.Column(db.String(50), nullable=False)
     port_number = db.Column(db.Integer, nullable=False)
+    port_protocol = db.Column(db.String(3), nullable=False)
     description = db.Column(db.String(100), nullable=False)
     order = db.Column(db.Integer, default=0)
 

--- a/utils/database/setting.py
+++ b/utils/database/setting.py
@@ -5,4 +5,4 @@ from .db import db
 class Setting(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     key = db.Column(db.String(50), unique=True, nullable=False)
-    value = db.Column(db.String(100), nullable=False)
+    value = db.Column(db.String(100), nullable=False, default='')

--- a/utils/routes/imports.py
+++ b/utils/routes/imports.py
@@ -49,7 +49,7 @@ def import_data():
 
         # Process the imported data and add to database
         for item in imported_data:
-            port = Port(ip_address=item['ip'], port_number=item['port'], description=item['description'])
+            port = Port(ip_address=item['ip'], port_number=item['port'], description=item['description'], port_protocol=item['port_protocol'])
             db.session.add(port)
         db.session.commit()
 
@@ -93,7 +93,8 @@ def import_caddyfile(content):
                     entries.append({
                         'ip': ip,
                         'port': int(port),
-                        'description': current_domain
+                        'description': current_domain,
+                        'port_protocol': 'tcp' # Assume TCP
                     })
 
     return entries
@@ -134,8 +135,8 @@ def import_docker_compose(content):
                 for port_mapping in ports:
                     if isinstance(port_mapping, str):
                         try:
-                            # Attempt to parse the port from the mapping
-                            parsed_port = parse_port(port_mapping)
+                            # Attempt to parse the port and protocol from the mapping
+                            parsed_port, protocol = parse_port_and_protocol(port_mapping)
 
                             # Use the image name as description, or fall back to service name
                             description = image if image else service_name
@@ -144,11 +145,12 @@ def import_docker_compose(content):
                             entries.append({
                                 'ip': '127.0.0.1',  # Assume localhost for all services
                                 'port': parsed_port,
-                                'description': description
+                                'description': description,
+                                'port_protocol': protocol
                             })
 
                             # Log the successfully added entry
-                            print(f"Added entry: IP: 127.0.0.1, Port: {parsed_port}, Description: {description}")
+                            print(f"Added entry: IP: 127.0.0.1, Port: {parsed_port}, Protocol: {protocol}, Description: {description}")
 
                         except ValueError as e:
                             # Log a warning if we couldn't parse the port
@@ -185,22 +187,23 @@ def import_json(content):
             entries.append({
                 'ip': item['ip_address'],
                 'port': int(item['port_number']),
-                'description': item['description']
+                'description': item['description'],
+                'port_protocol': item['port_protocol']
             })
         return entries
     except json.JSONDecodeError:
         raise ValueError("Invalid JSON format")
 
-def parse_port(port_value):
+def parse_port_and_protocol(port_value):
     """
-    Parse a port value, handling direct integers, environment variable expressions,
+    Parse a port value and protocol, handling direct integers, environment variable expressions,
     and complex port mappings.
 
     Args:
         port_value (str): The port value to parse
 
     Returns:
-        int or None: The parsed port number, or None if parsing fails
+        tuple: (int, str) The parsed port number and protocol ('tcp' or 'udp' if specified, else 'tcp')
 
     Raises:
         ValueError: If no valid port number can be found
@@ -208,24 +211,34 @@ def parse_port(port_value):
     # Remove any leading/trailing whitespace
     port_value = port_value.strip()
 
+    # Check for explicit protocol specification
+    if '/tcp' in port_value:
+        protocol = 'tcp'
+        port_value = port_value.replace('/tcp', '')
+    elif '/udp' in port_value:
+        protocol = 'udp'
+        port_value = port_value.replace('/udp', '')
+    else:
+        protocol = 'tcp'  # Default to TCP if not explicitly specified
+
     # Find the last colon in the string
     last_colon_index = port_value.rfind(':')
     if last_colon_index != -1:
-        # Look for numbers before the last colon
-        before_colon = port_value[:last_colon_index]
-        number_match = re.search(r'(\d+)', before_colon)
+        # Look for numbers after the last colon
+        after_colon = port_value[last_colon_index + 1:]
+        number_match = re.search(r'(\d+)', after_colon)
         if number_match:
-            return int(number_match.group(1))
+            return int(number_match.group(1)), protocol
 
-    # If no number found before the last colon, check for other patterns
+    # If no number found after the last colon, check for other patterns
     # Check for complete environment variable syntax with default value
     complete_env_var_match = re.search(r':-(\d+)', port_value)
     if complete_env_var_match:
-        return int(complete_env_var_match.group(1))
+        return int(complete_env_var_match.group(1)), protocol
 
     # Check if it's a direct integer
     if port_value.isdigit():
-        return int(port_value)
+        return int(port_value), protocol
 
     # If we can't parse it, raise an error
     raise ValueError(f"Unable to parse port value: {port_value}")

--- a/utils/routes/imports.py
+++ b/utils/routes/imports.py
@@ -94,7 +94,7 @@ def import_caddyfile(content):
                         'ip': ip,
                         'port': int(port),
                         'description': current_domain,
-                        'port_protocol': 'tcp' # Assume TCP
+                        'port_protocol': 'TCP' # Assume TCP
                     })
 
     return entries
@@ -188,7 +188,7 @@ def import_json(content):
                 'ip': item['ip_address'],
                 'port': int(item['port_number']),
                 'description': item['description'],
-                'port_protocol': item['port_protocol']
+                'port_protocol': item['port_protocol'].upper()
             })
         return entries
     except json.JSONDecodeError:
@@ -203,7 +203,7 @@ def parse_port_and_protocol(port_value):
         port_value (str): The port value to parse
 
     Returns:
-        tuple: (int, str) The parsed port number and protocol ('tcp' or 'udp' if specified, else 'tcp')
+        tuple: (int, str) The parsed port number and protocol ('TCP' or 'UDP' if specified, else 'TCP')
 
     Raises:
         ValueError: If no valid port number can be found
@@ -213,13 +213,13 @@ def parse_port_and_protocol(port_value):
 
     # Check for explicit protocol specification
     if '/tcp' in port_value:
-        protocol = 'tcp'
+        protocol = 'TCP'
         port_value = port_value.replace('/tcp', '')
     elif '/udp' in port_value:
-        protocol = 'udp'
+        protocol = 'UDP'
         port_value = port_value.replace('/udp', '')
     else:
-        protocol = 'tcp'  # Default to TCP if not explicitly specified
+        protocol = 'TCP'  # Default to TCP if not explicitly specified
 
     # Find the last colon in the string
     last_colon_index = port_value.rfind(':')

--- a/utils/routes/ports.py
+++ b/utils/routes/ports.py
@@ -241,8 +241,9 @@ def move_port():
     port_number = request.form.get('port_number')
     source_ip = request.form.get('source_ip')
     target_ip = request.form.get('target_ip')
+    protocol = request.form.get('protocol')
 
-    app.logger.info(f"Moving {port_number} from Source IP: {source_ip} to Target IP: {target_ip}")
+    app.logger.info(f"Moving {port_number} from Source IP: {source_ip} to Target IP: {target_ip} with protocol: {protocol}")
 
     if not all([port_number, source_ip, target_ip]):
         return jsonify({'success': False, 'message': 'Missing required data'}), 400

--- a/utils/routes/ports.py
+++ b/utils/routes/ports.py
@@ -243,18 +243,18 @@ def move_port():
     target_ip = request.form.get('target_ip')
     protocol = request.form.get('protocol')
 
-    app.logger.info(f"Moving {port_number} from Source IP: {source_ip} to Target IP: {target_ip} with protocol: {protocol}")
+    app.logger.info(f"Moving {port_number} ({protocol}) from Source IP: {source_ip} to Target IP: {target_ip}")
 
-    if not all([port_number, source_ip, target_ip]):
+    if not all([port_number, source_ip, target_ip, protocol]):
         return jsonify({'success': False, 'message': 'Missing required data'}), 400
 
     try:
-        # Check if the port already exists in the target IP
-        existing_port = Port.query.filter_by(port_number=port_number, ip_address=target_ip).first()
+        # Check if the port already exists in the target IP with the same protocol
+        existing_port = Port.query.filter_by(port_number=port_number, ip_address=target_ip, port_protocol=protocol).first()
         if existing_port:
-            return jsonify({'success': False, 'message': 'Port number already exists in the target IP group'}), 400
+            return jsonify({'success': False, 'message': 'Port number and protocol combination already exists in the target IP group'}), 400
 
-        port = Port.query.filter_by(port_number=port_number, ip_address=source_ip).first()
+        port = Port.query.filter_by(port_number=port_number, ip_address=source_ip, port_protocol=protocol).first()
         if port:
             # Update IP address
             port.ip_address = target_ip

--- a/utils/routes/ports.py
+++ b/utils/routes/ports.py
@@ -174,13 +174,14 @@ def generate_port():
     def get_setting(key, default):
         """Helper function to retrieve settings from the database."""
         setting = Setting.query.filter_by(key=key).first()
-        return setting.value if setting else default
+        value = setting.value if setting else str(default)
+        return value if value != '' else str(default)
 
     # Retrieve port generation settings
     port_start = int(get_setting('port_start', 1024))
     port_end = int(get_setting('port_end', 65535))
     port_exclude = get_setting('port_exclude', '')
-    port_length = int(get_setting('port_length', 0))
+    port_length = int(get_setting('port_length', 4))
 
     # Get existing ports for this IP
     existing_ports = set(p.port_number for p in Port.query.filter_by(ip_address=ip_address).all())

--- a/utils/routes/ports.py
+++ b/utils/routes/ports.py
@@ -44,6 +44,7 @@ def ports():
             'id': port.id,
             'port_number': port.port_number,
             'description': port.description,
+            'port_protocol': (port.port_protocol).upper(),
             'order': port.order
         })
 

--- a/utils/routes/ports.py
+++ b/utils/routes/ports.py
@@ -165,7 +165,8 @@ def generate_port():
     ip_address = request.form['ip_address']
     nickname = request.form['nickname']
     description = request.form['description']
-    app.logger.debug(f"Received request to generate port for IP: {ip_address}, Nickname: {nickname}, Description: {description}")
+    protocol = request.form['protocol']
+    app.logger.debug(f"Received request to generate port for IP: {ip_address}, Nickname: {nickname}, Description: {description}, Protocol: {protocol}")
 
     def get_setting(key, default):
         """Helper function to retrieve settings from the database."""
@@ -211,7 +212,7 @@ def generate_port():
 
     try:
         # Create and save the new port
-        port = Port(ip_address=ip_address, nickname=nickname, port_number=new_port, description=description)
+        port = Port(ip_address=ip_address, nickname=nickname, port_number=new_port, description=description, port_protocol=protocol)
         db.session.add(port)
         db.session.commit()
         app.logger.info(f"Generated new port {new_port} for IP: {ip_address}")
@@ -222,7 +223,7 @@ def generate_port():
 
     # Return the new port and full URL
     full_url = f"http://{ip_address}:{new_port}"
-    return jsonify({'port': new_port, 'full_url': full_url})
+    return jsonify({'protocol': protocol, 'port': new_port, 'full_url': full_url})
 
 @ports_bp.route('/move_port', methods=['POST'])
 def move_port():

--- a/utils/routes/settings.py
+++ b/utils/routes/settings.py
@@ -208,11 +208,10 @@ def export_entries():
                 'nickname': port.nickname,
                 'port_number': port.port_number,
                 'description': port.description,
+                'port_protocol': port.port_protocol,
                 'order': port.order
             } for port in ports
         ]
-
-        app.logger.info(f"Export Data: {port_data}")
 
         # Convert data to JSON
         json_data = json.dumps(port_data, indent=2)
@@ -225,6 +224,9 @@ def export_entries():
         # Generate filename with current date
         current_date = datetime.now().strftime("%Y-%m-%d")
         filename = f"portall_export_{current_date}.json"
+
+        # Log the export
+        app.logger.info(f"Exporting Data to: {filename}")
 
         return send_file(
             buffer,


### PR DESCRIPTION
## Added:
### Port Protocols
Portall now supports setting different protocols for ports (TCP/UDP).

You can choose protocols when generating new ports (default is TCP), when creating new ones, and when editing existing ones. Two identical port numbers can both be registered to a single IP if they have different protocols. If you try to add an entry that already has a matching port and protocol, it will trigger the Port Conflict Resolver.

If you add ports from an import, such as a Caddyfile or Docker-Compose, that doesn't explicitly state what protocols are being used, it will default to TCP.
### Loading Animation
Certain actions, like port conflict resolutions and moving IP panels, now trigger a loading animation that prevents further action until the changes have registered.
## Changed:
### Database
**Breaking Changes!** Database changes required for new port protocol feature.
### Docker-Compose Imports
Now supports `/tcp` and `/udp` properties to differentiate between the two protocols.
## Fixed:
### <a href="https://github.com/need4swede/Portall/issues/10" target="_blank">Settings Reset</a>
Fixed an issue where certain settings would reset if you made changes in the settings.